### PR TITLE
Add vocabulary practice page

### DIFF
--- a/js/vocab.js
+++ b/js/vocab.js
@@ -1,0 +1,35 @@
+(function(){
+  var words = [
+    {word: 'abandon', meaning: '\u653e\u5f03'},
+    {word: 'benefit', meaning: '\u76ca\u5904'},
+    {word: 'capable', meaning: '\u6709\u80fd\u529b\u7684'},
+    {word: 'declare', meaning: '\u5ba3\u5e03'},
+    {word: 'efficient', meaning: '\u9ad8\u6548\u7684'},
+    {word: 'feature', meaning: '\u7279\u70b9'},
+    {word: 'generate', meaning: '\u751f\u6210'},
+    {word: 'honest', meaning: '\u8bda\u5b9e\u7684'},
+    {word: 'issue', meaning: '\u95ee\u9898'},
+    {word: 'justice', meaning: '\u516c\u5e73'}
+  ];
+
+  var index = 0;
+
+  function showWord(){
+    $('#meaning').hide();
+    $('#flashcard').text(words[index].word);
+    $('#meaning').text(words[index].meaning);
+  }
+
+  $('#show-meaning').on('click', function(){
+    $('#meaning').toggle();
+  });
+
+  $('#next-word').on('click', function(){
+    index = (index + 1) % words.length;
+    showWord();
+  });
+
+  $(document).ready(function(){
+    showWord();
+  });
+})();

--- a/vocab.html
+++ b/vocab.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Vocabulary Practice</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/fancybox/jquery.fancybox.min.css">
+</head>
+<body>
+  <div id="container">
+    <div id="wrap">
+      <header id="header">
+        <div id="banner"></div>
+        <div id="header-outer" class="outer">
+          <div id="header-title" class="inner">
+            <h1 id="logo-wrap">
+              <a href="/" id="logo">Vocabulary</a>
+            </h1>
+          </div>
+          <div id="header-inner" class="inner">
+            <nav id="main-nav">
+              <a id="main-nav-toggle" class="nav-icon"></a>
+              <a class="main-nav-link" href="/">Home</a>
+              <a class="main-nav-link" href="/archives">Archives</a>
+            </nav>
+          </div>
+        </div>
+      </header>
+      <div class="outer">
+        <section id="main">
+          <div class="article-entry" style="text-align:center">
+            <h2>Word Practice</h2>
+            <div id="flashcard" style="font-size:2em;margin:20px;">Word</div>
+            <button id="show-meaning">Show Meaning</button>
+            <div id="meaning" style="display:none;margin:20px;"></div>
+            <button id="next-word" style="margin-top:20px;">Next Word</button>
+          </div>
+        </section>
+      </div>
+      <footer id="footer">
+        <div class="outer">
+          <div id="footer-info" class="inner">
+            &copy; 2021 Vocabulary Practice
+          </div>
+        </div>
+      </footer>
+    </div>
+    <nav id="mobile-nav">
+      <a href="/" class="mobile-nav-link">Home</a>
+      <a href="/archives" class="mobile-nav-link">Archives</a>
+    </nav>
+    <script src="/js/jquery-3.4.1.min.js"></script>
+    <script src="/fancybox/jquery.fancybox.min.js"></script>
+    <script src="/js/script.js"></script>
+    <script src="/js/vocab.js"></script>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a `vocab.html` page with a simple flashcard interface
- include `js/vocab.js` to cycle through English words and show translations

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68463add96f48326978eb127f8744ab0